### PR TITLE
fix(wordpress-all-in-one): Get Node LTS from Edge/Main

### DIFF
--- a/images/src/wordpress-all-in-one/Dockerfile
+++ b/images/src/wordpress-all-in-one/Dockerfile
@@ -10,7 +10,7 @@ RUN \
         nginx \
         mariadb mariadb-client \
         memcached \
-        nodejs npm python3 make g++ \
+        nodejs@edgem npm@edgem python3 make g++ \
         icu-data-full@edgem icu-libs@edgem libssl3@edgem ghostscript \
         imagemagick-libs@edgec \
         php8@edget \


### PR DESCRIPTION
Both PHP and Node.js depend on ICU, and it needs to be of the same version.